### PR TITLE
fix invalid suffix on literal on gcc-8

### DIFF
--- a/src/ngx_dynamic_healthcheck_http.cpp
+++ b/src/ngx_dynamic_healthcheck_http.cpp
@@ -44,7 +44,7 @@ healthcheck_http_helper::make_request(ngx_dynamic_healthcheck_opts_t *shared,
         is_unix_socket ? 0 : 1);
 
     buf->last = ngx_snprintf(buf->last, buf->end - buf->last,
-        "User-Agent: nginx/"NGINX_VERSION"\r\n"
+        "User-Agent: nginx/" NGINX_VERSION "\r\n"
         "Connection: %s\r\n",
         keepalive > c->requests + 1 ? "keep-alive" : "close");
 

--- a/src/ngx_http_dynamic_healthcheck.cpp
+++ b/src/ngx_http_dynamic_healthcheck.cpp
@@ -789,7 +789,7 @@ ngx_http_dynamic_healthcheck_get(ngx_http_request_t *r,
     if (upstream->not_found) {
         out->buf->last = ngx_snprintf(out->buf->last,
                                       out->buf->end - out->buf->last,
-                                      "{"CRLF);
+                                      "{" CRLF);
         tab = with_tab;
     }
  
@@ -841,7 +841,7 @@ ngx_http_dynamic_healthcheck_get(ngx_http_request_t *r,
             out->buf->last--;
         }
         out->buf->last = ngx_snprintf(out->buf->last,
-                                      out->buf->end - out->buf->last, "}"CRLF);
+                                      out->buf->end - out->buf->last, "}" CRLF);
     }
 
 skip:
@@ -849,7 +849,7 @@ skip:
     if (umcf == NULL || umcf->upstreams.nelts == 0)
         out->buf->last = ngx_snprintf(out->buf->last,
                                       out->buf->end - out->buf->last,
-                                      "{}"CRLF);
+                                      "{}" CRLF);
 
     out->buf->last_buf = (r == r->main) ? 1: 0;
     out->buf->last_in_chain = 1;
@@ -1318,7 +1318,7 @@ ngx_http_dynamic_healthcheck_status(ngx_http_request_t *r,
     if (upstream->not_found) {
         out->buf->last = ngx_snprintf(out->buf->last,
                                       out->buf->end - out->buf->last,
-                                      "{"CRLF);
+                                      "{" CRLF);
         tab = with_tab;
     }
 
@@ -1370,7 +1370,7 @@ ngx_http_dynamic_healthcheck_status(ngx_http_request_t *r,
             out->buf->last--;
         }
         out->buf->last = ngx_snprintf(out->buf->last,
-                                      out->buf->end - out->buf->last, "}"CRLF);
+                                      out->buf->end - out->buf->last, "}" CRLF);
     }
 
 skip:
@@ -1378,7 +1378,7 @@ skip:
     if (umcf == NULL || umcf->upstreams.nelts == 0)
         out->buf->last = ngx_snprintf(out->buf->last,
                                       out->buf->end - out->buf->last,
-                                      "{}"CRLF);
+                                      "{}" CRLF);
 
     out->buf->last_buf = (r == r->main) ? 1: 0;
     out->buf->last_in_chain = 1;


### PR DESCRIPTION
With gcc-8, build gonna be complain about `
error: invalid suffix on literal; C++11 requires a space between literal and string macro [-Werror=literal-suffix]`.

This PR should fix that.