### PR TITLE
switch to PCRE2

### DIFF
--- a/src/ngx_dynamic_healthcheck_api.cpp
+++ b/src/ngx_dynamic_healthcheck_api.cpp
@@ -1176,7 +1176,7 @@ ngx_dynamic_healthcheck_api_base::parse(ngx_dynamic_healthcheck_conf_t *conf,
     rc.err.len = NGX_MAX_CONF_ERRSTR;
     rc.err.data = errstr;
     rc.pool = pool;
-    rc.options = PCRE_UNGREEDY;
+    rc.options = PCRE2_UNGREEDY;
 
     rc.pattern = re;
 

--- a/src/ngx_dynamic_healthcheck_peer.cpp
+++ b/src/ngx_dynamic_healthcheck_peer.cpp
@@ -685,7 +685,7 @@ ngx_dynamic_healthcheck_match_buffer(ngx_str_t *pattern, ngx_str_t *s)
     rc.pattern = *pattern;
     rc.err.len = NGX_MAX_CONF_ERRSTR;
     rc.err.data = errstr;
-    rc.options = PCRE_DOTALL; 
+    rc.options = PCRE2_DOTALL; 
 
     rc.pool = ngx_create_pool(1024, ngx_cycle->log);
     if (rc.pool == NULL) {


### PR DESCRIPTION
```
 Changes with nginx 1.21.5                                        28 Dec 2021

    *) Change: now nginx is built with the PCRE2 library by default.
```
© https://nginx.org/en/CHANGES